### PR TITLE
Add numpy and scipy dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     author_email='f@bianp.net',
     url='http://pypi.python.org/pypi/copt',
     packages=['copt'],
+    install_requires=['numpy', 'scipy',],
     classifiers=[_f for _f in CLASSIFIERS.split('\n') if _f],
     package_data={'copt': ['data/img1.csv']},
     license='BSD'


### PR DESCRIPTION
Resolves #21.

Uninvited PR: this adds the numpy and scipy dependencies to `setup.py`.