### PR TITLE
Add pyproject.toml file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy", "scipy", "tqdm", "sklearn", "six"]  # PEP 518 specifications.

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     author_email='f@bianp.net',
     url='http://pypi.python.org/pypi/copt',
     packages=['copt'],
-    install_requires=['numpy', 'scipy',],
+    install_requires=['numpy', 'scipy', 'tqdm', 'sklearn', 'six',],
     classifiers=[_f for _f in CLASSIFIERS.split('\n') if _f],
     package_data={'copt': ['data/img1.csv']},
     license='BSD'


### PR DESCRIPTION
Resolves #21, really this time.

Also adds tqdm, sklearn, and six to install_requires in setup.py

See further comments in #21. pip installation was failing because the build environment lacked numpy, scipy, tqdm, sklearn, and six. Once the installation succeeded, I would still get the same errors on `import copt` until I also added those same packages to `setup.py`'s `install_requires` parameter.

Note that `pip install -e` is allowed with the new `pyproject.toml` file provided one writes

```bash
pip install --no-use-pep517 -e .
```
and NOT
```bash
pip install -e --no-use-pep517 .
```
for reasons that remain opaque to me.