### PR TITLE
Fix early termination criterion

### DIFF
--- a/copt/proximal_gradient.py
+++ b/copt/proximal_gradient.py
@@ -105,7 +105,7 @@ def minimize_proximal_gradient(
     pbar = trange(max_iter, disable=(verbose == 0))
     for it in pbar:
       if callback is not None:
-        if not callback(locals()):
+        if callback(locals()) is False:
           break
       # .. compute gradient and step size
       if hasattr(step_size, "__call__"):
@@ -159,7 +159,7 @@ def minimize_proximal_gradient(
     pbar = trange(max_iter, disable=(verbose == 0))
     for it in pbar:
       if callback is not None:
-        if not callback(locals()):
+        if callback(locals()) is False:
           break
 
       # .. compute gradient and step size

--- a/copt/splitting.py
+++ b/copt/splitting.py
@@ -54,8 +54,10 @@ def minimize_three_split(f_grad,
     step_size : float
         Starting value for the line-search procedure.
 
-    callback : callable
-        callback function (optional).
+    callback : callable.
+        callback function (optional). Takes a single argument (x) with the
+        current coefficients in the algorithm. The algorithm will exit if
+        callback returns False.
 
     Returns
     -------
@@ -140,7 +142,7 @@ def minimize_three_split(f_grad,
     pbar.set_postfix(tol=certificate, step_size=step_size)
 
     if callback is not None:
-      if not callback(locals()):
+      if callback(locals()) is False:
         break
 
     if it > 0 and certificate < tol:
@@ -206,8 +208,10 @@ def minimize_primal_dual(f_grad,
     verbose : int
         Verbosity level, from 0 (no output) to 2 (output on each iteration)
 
-    callback : callable
-        callback function (optional).
+    callback : callable.
+        callback function (optional). Takes a single argument (x) with the
+        current coefficients in the algorithm. The algorithm will exit if
+        callback returns False.
 
     Returns
     -------
@@ -315,7 +319,7 @@ def minimize_primal_dual(f_grad,
       break
 
     if callback is not None:
-      if not callback(locals()):
+      if callback(locals()) is False:
         break
 
   if it >= max_iter:


### PR DESCRIPTION
Resolves #24

This PR fixes the `break` criteria in `splitting.py` and `proximal_gradient.py`. It also updates the `callback` docstring entries in splitting.py.