### PR TITLE
LMO repeat bug fix in example script

### DIFF
--- a/copt/datasets.py
+++ b/copt/datasets.py
@@ -2,6 +2,7 @@
 import hashlib
 import os
 import urllib
+import urllib.request
 import tarfile
 
 import numpy as np

--- a/examples/frank_wolfe/plot_vertex_overlap.py
+++ b/examples/frank_wolfe/plot_vertex_overlap.py
@@ -44,7 +44,7 @@ for ax, (dataset_title, load_data) in zip(axes.ravel(), datasets):
 
     def trace(kw):
       """Store vertex overlap during execution of the algorithm."""
-      s_t = kw["update_direction"] - kw["x"]
+      s_t = kw["update_direction"] + kw["x"]
       if dt_prev:
         # check if the vertex of this and the previous iterate
         # coincide. Since these might be sparse vectors, we use


### PR DESCRIPTION
Gotta use a plus instead of a minus. Also added an import to datasets which wasn't working properly on my laptop.

Here's the current output:
![lmo_repeats](https://user-images.githubusercontent.com/2163686/78273882-b5022f80-750f-11ea-9ff2-d4526b2d69cb.png)
