### PR TITLE
Unify API for step-size between proximal gradient descent and frank-w…

### DIFF
--- a/copt/proximal_gradient.py
+++ b/copt/proximal_gradient.py
@@ -79,7 +79,8 @@ def minimize_proximal_gradient(
         callback returns False.
 
     step : "backtracking" or callable.
-        Step-size to use. "backtracking" will use a backtracking line-search.
+        Step-size strategy to use. "backtracking" will use a backtracking line-search,
+        while callable will use the value returned by step(locals()).
 
     accelerated: boolean
         Whether to use the accelerated variant of the algorithm.

--- a/examples/frank_wolfe/plot_vertex_overlap.py
+++ b/examples/frank_wolfe/plot_vertex_overlap.py
@@ -19,67 +19,62 @@ datasets = [
     ("Gisette", cp.datasets.load_gisette),
     ("RCV1", cp.datasets.load_rcv1),
     ("Madelon", cp.datasets.load_madelon),
-    ("Covtype", cp.datasets.load_covtype)
-    ]
+    ("Covtype", cp.datasets.load_covtype),
+]
 
 
 fig, axes = plt.subplots(nrows=2, ncols=2, figsize=(10, 5))
 for ax, (dataset_title, load_data) in zip(axes.ravel(), datasets):
-  print("Running on the %s dataset" % dataset_title)
+    print("Running on the %s dataset" % dataset_title)
 
-  X, y = load_data()
-  n_samples, n_features = X.shape
+    X, y = load_data()
+    n_samples, n_features = X.shape
 
-  l1_ball = cp.utils.L1Ball(n_features / 2.)
-  f = cp.utils.LogLoss(X, y)
-  x0 = np.zeros(n_features)
+    l1_ball = cp.utils.L1Ball(n_features / 2.0)
+    f = cp.utils.LogLoss(X, y)
+    x0 = np.zeros(n_features)
 
-  for i, (step_size, label, marker) in enumerate([
-      ["adaptive", "Frank-Wolfe adaptive step-size", "^"],
-      ["adaptive3", "adaptive++ step-size", "s"],
-      [None, "Lipschitz step-size", "d"]
-      ]):
-    print("Running %s variant" % label)
-    st_prev = []
-    overlap = []
+    for i, (step, label, marker) in enumerate(
+        [["backtracking", "backtracking", "^"], ["DR", "DR step-size", "d"]]
+    ):
+        print("Running %s variant" % label)
+        st_prev = []
+        overlap = []
 
-    def trace(kw):
-      """Store vertex overlap during execution of the algorithm."""
-      s_t = kw["update_direction"] + kw["x"]
-      if st_prev:
-        # check if the vertex of this and the previous iterate
-        # coincide. Since these might be sparse vectors, we use
-        # sparse.linalg.norm to make the comparison
-        prev_overlap = overlap[-1]
-        if np.linalg.norm(st_prev[0] - s_t) == 0:
-          overlap.append(prev_overlap + 1)
-        else:
-          overlap.append(prev_overlap)
-        st_prev[0] = s_t
-      else:
-        overlap.append(0)
-        st_prev.append(s_t)
+        def trace(kw):
+            """Store vertex overlap during execution of the algorithm."""
+            s_t = kw["update_direction"] + kw["x"]
+            if st_prev:
+                # check if the vertex of this and the previous iterate
+                # coincide. Since these might be sparse vectors, we use
+                # sparse.linalg.norm to make the comparison
+                prev_overlap = overlap[-1]
+                if np.linalg.norm(st_prev[0] - s_t) == 0:
+                    overlap.append(prev_overlap + 1)
+                else:
+                    overlap.append(prev_overlap)
+                st_prev[0] = s_t
+            else:
+                overlap.append(0)
+                st_prev.append(s_t)
 
-    if label.startswith("Frank-Wolfe"):
-      cp.minimize_frank_wolfe(
-          f.f_grad,
-          x0,
-          l1_ball.lmo,
-          callback=trace,
-          max_iter=50,
-          step_size=step_size,
-          verbose=True,
-          lipschitz=f.lipschitz,
-      )
-    elif label.startswith("Pairwise"):
-      pass
-    ax.plot(overlap, label=label, marker=marker, markevery=7 + i)
-    ax.yaxis.set_major_locator(MaxNLocator(integer=True))
-    ax.legend()
-  ax.set_xlabel("number of iterations")
-  ax.set_ylabel("LMO overlap")
-  ax.set_title(dataset_title)
-  fig.tight_layout()  # otherwise the right y-label is slightly clipped
-  ax.grid()
+        cp.minimize_frank_wolfe(
+            f.f_grad,
+            x0,
+            l1_ball.lmo,
+            callback=trace,
+            max_iter=50,
+            step=step,
+            verbose=True,
+            lipschitz=f.lipschitz,
+        )
+        ax.plot(overlap, label=label, marker=marker, markevery=7 + i)
+        ax.yaxis.set_major_locator(MaxNLocator(integer=True))
+        ax.legend()
+    ax.set_xlabel("number of iterations")
+    ax.set_ylabel("LMO overlap")
+    ax.set_title(dataset_title)
+    fig.tight_layout()  # otherwise the right y-label is slightly clipped
+    ax.grid()
 # plt.legend()
 plt.show()

--- a/tests/test_frank_wolfe.py
+++ b/tests/test_frank_wolfe.py
@@ -38,7 +38,7 @@ def test_fw_api():
     # check that we riase an exception when the DR step-size is used
     # but no lipschitz constant is given
     with pytest.raises(ValueError):
-        cp.minimize_frank_wolfe(f.f_grad, [0] * n_features, l1ball.lmo, step_size="DR")
+        cp.minimize_frank_wolfe(f.f_grad, [0] * n_features, l1ball.lmo, step="DR")
 
 
 @pytest.mark.parametrize("alpha", [0.1, 1.0, 10.0, 100.0])
@@ -89,8 +89,8 @@ def bisection(kw):
 
 @pytest.mark.parametrize("alpha", [0.1, 1.0, 10.0, 100.0])
 @pytest.mark.parametrize("obj", LOSS_FUNCS)
-@pytest.mark.parametrize("step_size", ["DR", "adaptive", "oblivious", bisection])
-def test_fw_backtrack(obj, step_size, alpha):
+@pytest.mark.parametrize("step", ["DR", "backtracking", "oblivious", bisection])
+def test_fw_backtrack(obj, step, alpha):
     """Test FW with different options of the line-search strategy."""
     f = obj(A, b, 1.0 / n_samples)
     traceball = cp.utils.TraceBall(alpha, (4, 4))
@@ -100,7 +100,7 @@ def test_fw_backtrack(obj, step_size, alpha):
         traceball.lmo,
         tol=0,
         lipschitz=f.lipschitz,
-        step_size=step_size,
+        step=step,
         max_iter=1000,
     )
     assert np.isfinite(opt.x).sum() == n_features
@@ -113,8 +113,8 @@ def test_fw_backtrack(obj, step_size, alpha):
 
 @pytest.mark.parametrize("alpha", [0.1, 1.0, 10.0, 100.0])
 @pytest.mark.parametrize("obj", LOSS_FUNCS)
-@pytest.mark.parametrize("step_size", ["DR", "adaptive", bisection])
-def test_pairwise_fw(obj, step_size, alpha):
+@pytest.mark.parametrize("step", ["DR", "backtracking", bisection])
+def test_pairwise_fw(obj, step, alpha):
     """Test the Pairwise FW method."""
     f = obj(A, b, 1.0 / n_samples)
 
@@ -123,12 +123,7 @@ def test_pairwise_fw(obj, step_size, alpha):
     x0[0] = alpha
     cb = cp.utils.Trace(f)
     opt = cp.minimize_frank_wolfe(
-        f.f_grad,
-        x0,
-        l1ball.lmo_pairwise,
-        step_size=step_size,
-        lipschitz=f.lipschitz,
-        callback=cb,
+        f.f_grad, x0, l1ball.lmo_pairwise, step=step, lipschitz=f.lipschitz, callback=cb
     )
     assert np.isfinite(opt.x).sum() == n_features
 


### PR DESCRIPTION
Unify API for step-size between proximal gradient descent and frank-w

  * Changed the step-size parameter to have the same name as in gradient descent.

  * Random documentation improvements. Changed names to model better our backtracking paper.

  * Fixed plot_vertex_overlap.py, so that two step-size strategies
  are displayed and also fixed indentation to use 4 spaces.