### PR TITLE
add requests lib to basic requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 scipy
+requests
 pytest >= 3.8.0


### PR DESCRIPTION
Best if examples run start to finish on default install. Don't understand how this works on the CI machines, but perhaps there is some sort of caching taking place of the example datasets.

Creating PR since I know we want to keep dependencies small.