### PR TITLE
Stochastic FW speed up

### DIFF
--- a/copt/randomized.py
+++ b/copt/randomized.py
@@ -720,7 +720,6 @@ def step_size_sfw(variant):
 SFW_VARIANTS = {'SAG', 'SAGA', 'MHK', 'LF'}
 
 
-@profile
 def minimize_sfw(
         f_deriv,
         A,

--- a/copt/utils.py
+++ b/copt/utils.py
@@ -80,14 +80,17 @@ def safe_sparse_add(a, b):
 @njit(nogil=True)
 def fast_csr_vm(x, data, indptr, indices, d, idx):
     """
+    Returns the vector matrix product x * M[idx]. M is described
+    in the csr format.
 
-    :param x:
-    :param data:
-    :param indptr:
-    :param indices:
-    :param d:
-    :param idx:
-    :return:
+    Returns x * M[idx]
+
+    x: 1-d iterable
+    data: data field of a scipy.sparse.csr_matrix
+    indptr: indptr field of a scipy.sparse.csr_matrix
+    indices: indices field of a scipy.sparse.csr_matrix
+    d: output dimension
+    idx: 1-d iterable: index of the sparse.csr_matrix
     """
     res = np.zeros(d)
     assert x.shape[0] == len(idx)
@@ -101,14 +104,16 @@ def fast_csr_vm(x, data, indptr, indices, d, idx):
 @njit(nogil=True)
 def fast_csr_mv(data, indptr, indices, x, idx):
     """
+    Returns the matrix vector product M[idx] * x. M is described
+    in the csr format.
 
-    :param data:
-    :param indptr:
-    :param indices:
-    :param x:
-    :param idx:
-    :return:
+    data: data field of a scipy.sparse.csr_matrix
+    indptr: indptr field of a scipy.sparse.csr_matrix
+    indices: indices field of a scipy.sparse.csr_matrix
+    x: 1-d iterable
+    idx: 1-d iterable: index of the sparse.csr_matrix
     """
+
     res = np.zeros(len(idx))
     for i, row_idx in np.ndenumerate(idx):
         for k, j in enumerate(range(indptr[row_idx], indptr[row_idx+1])):

--- a/copt/utils.py
+++ b/copt/utils.py
@@ -77,6 +77,21 @@ def safe_sparse_add(a, b):
                 b = b.ravel()
         return a + b
 
+@njit
+def csr_left_mul(x, data, indptr, indices, d, idx):
+    """
+    :param x: numpy.ndarray
+    :param A: scipy.sparse.csr_matrix
+    :return: x.dot(A)
+    """
+    res = np.zeros(d)
+    assert x.shape[0] == len(idx)
+    for k, i in np.ndenumerate(idx):
+        for j in range(indptr[i], indptr[i+1]):
+            j_idx = indices[j]
+            res[j_idx] += x[k] * data[j]
+    return res
+
 
 def parse_step_size(step_size):
     if hasattr(step_size, "__len__") and len(step_size) == 2:

--- a/copt/utils.py
+++ b/copt/utils.py
@@ -77,12 +77,17 @@ def safe_sparse_add(a, b):
                 b = b.ravel()
         return a + b
 
-@njit
-def csr_left_mul(x, data, indptr, indices, d, idx):
+@njit(nogil=True)
+def fast_csr_vm(x, data, indptr, indices, d, idx):
     """
-    :param x: numpy.ndarray
-    :param A: scipy.sparse.csr_matrix
-    :return: x.dot(A)
+
+    :param x:
+    :param data:
+    :param indptr:
+    :param indices:
+    :param d:
+    :param idx:
+    :return:
     """
     res = np.zeros(d)
     assert x.shape[0] == len(idx)
@@ -90,6 +95,25 @@ def csr_left_mul(x, data, indptr, indices, d, idx):
         for j in range(indptr[i], indptr[i+1]):
             j_idx = indices[j]
             res[j_idx] += x[k] * data[j]
+    return res
+
+
+@njit(nogil=True)
+def fast_csr_mv(data, indptr, indices, x, idx):
+    """
+
+    :param data:
+    :param indptr:
+    :param indices:
+    :param x:
+    :param idx:
+    :return:
+    """
+    res = np.zeros(len(idx))
+    for i, row_idx in np.ndenumerate(idx):
+        for k, j in enumerate(range(indptr[row_idx], indptr[row_idx+1])):
+            j_idx = indices[j]
+            res[i] += x[j_idx] * data[j]
     return res
 
 

--- a/examples/frank_wolfe/plot_sfw.py
+++ b/examples/frank_wolfe/plot_sfw.py
@@ -15,6 +15,7 @@ n_samples, n_features = 1000, 200
 np.random.seed(0)
 X = np.random.randn(n_samples, n_features)
 y = np.random.rand(n_samples)
+batch_size = 1
 max_iter = int(1e6)
 freq = max(max_iter // 1000, 1000)
 
@@ -52,6 +53,7 @@ result_sfw_SAG = cp.minimize_sfw(
     y,
     np.zeros(n_features),
     constraint.lmo,
+    batch_size,
     callback=cb_sfw_SAG,
     tol=0,
     max_iter=max_iter,
@@ -64,6 +66,7 @@ result_sfw_SAGA = cp.minimize_sfw(
     y,
     np.zeros(n_features),
     constraint.lmo,
+    batch_size,
     callback=cb_sfw_SAGA,
     tol=0,
     max_iter=max_iter,
@@ -76,6 +79,7 @@ result_sfw_mokhtari = cp.minimize_sfw(
     y,
     np.zeros(n_features),
     constraint.lmo,
+    batch_size,
     callback=cb_sfw_mokhtari,
     tol=0,
     max_iter=max_iter,
@@ -88,6 +92,7 @@ result_sfw_lu_freund = cp.minimize_sfw(
     y,
     np.zeros(n_features),
     constraint.lmo,
+    batch_size,
     callback=cb_sfw_lu_freund,
     tol=0,
     max_iter=max_iter,

--- a/examples/frank_wolfe/plot_sfw_real_data.py
+++ b/examples/frank_wolfe/plot_sfw_real_data.py
@@ -6,10 +6,10 @@ The problem solved in this case is a L1 constrained logistic regression
 (sometimes referred to as sparse logistic regression).
 """
 
-import copt as cp
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+import copt as cp
 
 # .. Load dataset ..
 np.random.seed(0)
@@ -41,49 +41,49 @@ class TraceGaps(cp.utils.Trace):
         super(TraceGaps, self).__call__(dl)
 
 
-cb_sfw_SAG = TraceGaps(f, freq=freq)
-cb_sfw_mokhtari = TraceGaps(f, freq=freq)
-cb_sfw_lu_freund = TraceGaps(f, freq=freq)
+cb_SAG = TraceGaps(f, freq=freq)
+cb_MHK = TraceGaps(f, freq=freq)
+cb_LF = TraceGaps(f, freq=freq)
 
 
 # .. run the SFW algorithm ..
 print("Running SAGFW")
-result_sfw_SAG = cp.minimize_sfw(
+result_SAG = cp.minimize_sfw(
     f.partial_deriv,
     X,
     y,
     np.zeros(n_features),
     constraint.lmo,
     batch_size,
-    callback=cb_sfw_SAG,
+    callback=cb_SAG,
     tol=0,
     max_iter=max_iter,
     variant='SAG'
 )
 
 print("Running MHK")
-result_sfw_mokhtari = cp.minimize_sfw(
+result_MHK = cp.minimize_sfw(
     f.partial_deriv,
     X,
     y,
     np.zeros(n_features),
     constraint.lmo,
     batch_size,
-    callback=cb_sfw_mokhtari,
+    callback=cb_MHK,
     tol=0,
     max_iter=max_iter,
     variant='MHK'
 )
 
 print("Running LF")
-result_sfw_lu_freund = cp.minimize_sfw(
+result_LF = cp.minimize_sfw(
     f.partial_deriv,
     X,
     y,
     np.zeros(n_features),
     constraint.lmo,
     batch_size,
-    callback=cb_sfw_lu_freund,
+    callback=cb_LF,
     tol=0,
     max_iter=max_iter,
     variant='LF'
@@ -91,36 +91,35 @@ result_sfw_lu_freund = cp.minimize_sfw(
 
 print("Plotting...")
 # .. plot the result ..
-max_gap = max(cb_sfw_SAG.trace_gaps[0],
-              cb_sfw_mokhtari.trace_gaps[0],
-              cb_sfw_lu_freund.trace_gaps[0],
+max_gap = max(cb_SAG.trace_gaps[0],
+              cb_MHK.trace_gaps[0],
+              cb_LF.trace_gaps[0],
               )
 
-max_val = max(np.max(cb_sfw_SAG.trace_fx),
-              np.max(cb_sfw_mokhtari.trace_fx),
-              np.max(cb_sfw_lu_freund.trace_fx),
+max_val = max(np.max(cb_SAG.trace_fx),
+              np.max(cb_MHK.trace_fx),
+              np.max(cb_LF.trace_fx),
               )
 
-min_val = min(np.min(cb_sfw_SAG.trace_fx),
-              np.min(cb_sfw_mokhtari.trace_fx),
-              np.min(cb_sfw_lu_freund.trace_fx),
+min_val = min(np.min(cb_SAG.trace_fx),
+              np.min(cb_MHK.trace_fx),
+              np.min(cb_LF.trace_fx),
               )
 
 fig, (ax1, ax2) = plt.subplots(2, sharex=True)
 fig.suptitle("Sparse Logistic Regression -- {}".format(dataset_name), fontweight="bold")
 
-ax1.plot(batch_size * freq * np.arange(len(cb_sfw_SAG.trace_gaps)), np.array(cb_sfw_SAG.trace_gaps) / max_gap, label="SFW -- SAG")
-ax1.plot(batch_size * freq * np.arange(len(cb_sfw_mokhtari.trace_gaps)), np.array(cb_sfw_mokhtari.trace_gaps) / max_gap, label='SFW -- Mokhtari et al. (2020)')
-ax1.plot(batch_size * freq * np.arange(len(cb_sfw_lu_freund.trace_gaps)), np.array(cb_sfw_lu_freund.trace_gaps) / max_gap, label='SFW -- Lu and Freund (2020)')
+ax1.plot(batch_size * freq * np.arange(len(cb_SAG.trace_gaps)), np.array(cb_SAG.trace_gaps) / max_gap, label="SFW -- SAG")
+ax1.plot(batch_size * freq * np.arange(len(cb_MHK.trace_gaps)), np.array(cb_MHK.trace_gaps) / max_gap, label='SFW -- Mokhtari et al. (2020)')
+ax1.plot(batch_size * freq * np.arange(len(cb_LF.trace_gaps)), np.array(cb_LF.trace_gaps) / max_gap, label='SFW -- Lu and Freund (2020)')
 ax1.set_ylabel("Relative FW gap", fontweight="bold")
 ax1.set_yscale('log')
 ax1.grid()
 
-matplotlib.rc('text', usetex=True)
 
-ax2.plot(batch_size * freq * np.arange(len(cb_sfw_SAG.trace_fx)), (np.array(cb_sfw_SAG.trace_fx) - min_val) / (max_val - min_val), label="SFW -- Ours")
-ax2.plot(batch_size * freq * np.arange(len(cb_sfw_mokhtari.trace_fx)), (np.array(cb_sfw_mokhtari.trace_fx) - min_val) / (max_val - min_val), label='SFW -- Mokhtari et al. (2018)')
-ax2.plot(batch_size * freq * np.arange(len(cb_sfw_lu_freund.trace_fx)), (np.array(cb_sfw_lu_freund.trace_fx) - min_val) / (max_val - min_val), label='SFW -- Lu and Freund (2020)')
+ax2.plot(batch_size * freq * np.arange(len(cb_SAG.trace_fx)), (np.array(cb_SAG.trace_fx) - min_val) / (max_val - min_val), label="SFW -- Ours")
+ax2.plot(batch_size * freq * np.arange(len(cb_MHK.trace_fx)), (np.array(cb_MHK.trace_fx) - min_val) / (max_val - min_val), label='SFW -- Mokhtari et al. (2018)')
+ax2.plot(batch_size * freq * np.arange(len(cb_LF.trace_fx)), (np.array(cb_LF.trace_fx) - min_val) / (max_val - min_val), label='SFW -- Lu and Freund (2020)')
 ax2.set_ylabel("Relative suboptimality", fontweight="bold")
 ax2.set_xlabel("Number of gradient evaluations", fontweight="bold")
 ax2.set_yscale("log")

--- a/examples/frank_wolfe/plot_sfw_real_data.py
+++ b/examples/frank_wolfe/plot_sfw_real_data.py
@@ -7,22 +7,22 @@ The problem solved in this case is a L1 constrained logistic regression
 """
 
 import copt as cp
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 
-# .. construct (random) dataset ..
-n_samples, n_features = 1000, 200
+# .. Load dataset ..
 np.random.seed(0)
-X = np.random.randn(n_samples, n_features)
-y = np.random.rand(n_samples)
-batch_size = 50
-max_iter = int(1e3)
-freq = max(max_iter * n_samples // (batch_size * 500), 1)
+X, y = cp.datasets.load_rcv1("train")
+dataset_name = "RCV1"
+n_samples, n_features = X.shape
+batch_size = 100
+max_iter = int(1e1)
+freq = max(max_iter * n_samples // (batch_size * 1000), 1)
 
 # .. objective function and regularizer ..
 f = cp.utils.LogLoss(X, y)
-constraint = cp.utils.L1Ball(1.)
-
+constraint = cp.utils.L1Ball(2e3)
 
 # .. callbacks to track progress ..
 def fw_gap(x):
@@ -42,9 +42,9 @@ class TraceGaps(cp.utils.Trace):
 
 
 cb_sfw_SAG = TraceGaps(f, freq=freq)
-cb_sfw_SAGA = TraceGaps(f, freq=freq)
 cb_sfw_mokhtari = TraceGaps(f, freq=freq)
 cb_sfw_lu_freund = TraceGaps(f, freq=freq)
+
 
 # .. run the SFW algorithm ..
 print("Running SAGFW")
@@ -59,20 +59,6 @@ result_sfw_SAG = cp.minimize_sfw(
     tol=0,
     max_iter=max_iter,
     variant='SAG'
-)
-
-print("Running SAGAFW")
-result_sfw_SAGA = cp.minimize_sfw(
-    f.partial_deriv,
-    X,
-    y,
-    np.zeros(n_features),
-    constraint.lmo,
-    batch_size,
-    callback=cb_sfw_SAGA,
-    tol=0,
-    max_iter=max_iter,
-    variant='SAGA'
 )
 
 print("Running MHK")
@@ -102,42 +88,44 @@ result_sfw_lu_freund = cp.minimize_sfw(
     max_iter=max_iter,
     variant='LF'
 )
+
+print("Plotting...")
 # .. plot the result ..
 max_gap = max(cb_sfw_SAG.trace_gaps[0],
               cb_sfw_mokhtari.trace_gaps[0],
               cb_sfw_lu_freund.trace_gaps[0],
-              cb_sfw_SAGA.trace_gaps[0])
+              )
 
-max_val = max(cb_sfw_SAG.trace_fx[0],
-              cb_sfw_mokhtari.trace_fx[0],
-              cb_sfw_lu_freund.trace_fx[0],
-              cb_sfw_SAGA.trace_fx[0])
+max_val = max(np.max(cb_sfw_SAG.trace_fx),
+              np.max(cb_sfw_mokhtari.trace_fx),
+              np.max(cb_sfw_lu_freund.trace_fx),
+              )
 
 min_val = min(np.min(cb_sfw_SAG.trace_fx),
               np.min(cb_sfw_mokhtari.trace_fx),
               np.min(cb_sfw_lu_freund.trace_fx),
-              np.min(cb_sfw_SAGA.trace_fx),
               )
 
 fig, (ax1, ax2) = plt.subplots(2, sharex=True)
-fig.suptitle('Stochastic Frank-Wolfe')
+fig.suptitle("Sparse Logistic Regression -- {}".format(dataset_name), fontweight="bold")
 
-ax1.plot(freq * np.arange(len(cb_sfw_SAG.trace_gaps)), np.array(cb_sfw_SAG.trace_gaps) / max_gap, label="SFW -- SAG")
-ax1.plot(freq * np.arange(len(cb_sfw_SAGA.trace_gaps)), np.array(cb_sfw_SAGA.trace_gaps) / max_gap, label="SFW -- SAGA")
-ax1.plot(freq * np.arange(len(cb_sfw_mokhtari.trace_gaps)), np.array(cb_sfw_mokhtari.trace_gaps) / max_gap, label='SFW -- Mokhtari et al. (2020)')
-ax1.plot(freq * np.arange(len(cb_sfw_lu_freund.trace_gaps)), np.array(cb_sfw_lu_freund.trace_gaps) / max_gap, label='SFW -- Lu and Freund (2020)')
+ax1.plot(batch_size * freq * np.arange(len(cb_sfw_SAG.trace_gaps)), np.array(cb_sfw_SAG.trace_gaps) / max_gap, label="SFW -- SAG")
+ax1.plot(batch_size * freq * np.arange(len(cb_sfw_mokhtari.trace_gaps)), np.array(cb_sfw_mokhtari.trace_gaps) / max_gap, label='SFW -- Mokhtari et al. (2020)')
+ax1.plot(batch_size * freq * np.arange(len(cb_sfw_lu_freund.trace_gaps)), np.array(cb_sfw_lu_freund.trace_gaps) / max_gap, label='SFW -- Lu and Freund (2020)')
 ax1.set_ylabel("Relative FW gap", fontweight="bold")
 ax1.set_yscale('log')
 ax1.grid()
 
-ax2.plot(freq * np.arange(len(cb_sfw_SAG.trace_fx)), (np.array(cb_sfw_SAG.trace_fx) - min_val) / (max_val - min_val), label="SFW -- SAG")
-ax2.plot(freq * np.arange(len(cb_sfw_SAGA.trace_fx)), (np.array(cb_sfw_SAGA.trace_fx) - min_val) / (max_val - min_val), label="SFW -- SAGA")
-ax2.plot(freq * np.arange(len(cb_sfw_mokhtari.trace_fx)), (np.array(cb_sfw_mokhtari.trace_fx) - min_val) / (max_val - min_val), label='SFW -- Mokhtari et al. (2018)')
-ax2.plot(freq * np.arange(len(cb_sfw_lu_freund.trace_fx)), (np.array(cb_sfw_lu_freund.trace_fx) - min_val) / (max_val - min_val), label='SFW -- Lu and Freund (2020)')
+matplotlib.rc('text', usetex=True)
+
+ax2.plot(batch_size * freq * np.arange(len(cb_sfw_SAG.trace_fx)), (np.array(cb_sfw_SAG.trace_fx) - min_val) / (max_val - min_val), label="SFW -- Ours")
+ax2.plot(batch_size * freq * np.arange(len(cb_sfw_mokhtari.trace_fx)), (np.array(cb_sfw_mokhtari.trace_fx) - min_val) / (max_val - min_val), label='SFW -- Mokhtari et al. (2018)')
+ax2.plot(batch_size * freq * np.arange(len(cb_sfw_lu_freund.trace_fx)), (np.array(cb_sfw_lu_freund.trace_fx) - min_val) / (max_val - min_val), label='SFW -- Lu and Freund (2020)')
 ax2.set_ylabel("Relative suboptimality", fontweight="bold")
 ax2.set_xlabel("Number of gradient evaluations", fontweight="bold")
 ax2.set_yscale("log")
-
-plt.legend()
-plt.grid()
+ax2.legend()
+ax2.grid()
 plt.show()
+
+print("Done.")

--- a/tests/test_matmul_speedup.py
+++ b/tests/test_matmul_speedup.py
@@ -1,0 +1,23 @@
+import scipy.sparse as sparse
+import numpy as np
+import copt as cp
+
+n_samples, n_features = 1000, 100
+n_subset = 5
+A_sparse = sparse.rand(n_samples, n_features, density=0.5, format="csr")
+x = np.random.rand(n_features)
+u = np.random.rand(n_subset)
+idx = np.random.choice(n_samples, n_subset)
+
+
+def test_fast_csr_vm():
+    res = cp.utils.fast_csr_vm(u,
+                               A_sparse.data, A_sparse.indptr, A_sparse.indices,
+                               n_features, idx)
+    assert np.allclose(res, cp.utils.safe_sparse_dot(u, A_sparse[idx]))
+
+
+def test_fast_csr_mv():
+    res = cp.utils.fast_csr_mv(A_sparse.data, A_sparse.indptr, A_sparse.indices,
+                               x, idx)
+    assert np.allclose(res, cp.utils.safe_sparse_dot(A_sparse[idx], x))

--- a/tests/test_stochastic_fw.py
+++ b/tests/test_stochastic_fw.py
@@ -103,7 +103,7 @@ def test_sfw_gap_traceback(variant, loss_grad, alpha):
                                              fmt)
                                for fmt in ['coo', 'csr', 'csc', 'lil']])
 def test_sfw_sparse(variant, A):
-    """Check that SFW algorithms run on sparse data matrices and initial values."""
+    """Check that SFW algorithms run on sparse data matrices."""
 
     f = cp.utils.LogLoss(A, b, 1.0 / n_samples)
     cb = cp.utils.Trace(f)


### PR DESCRIPTION
Bottlenecks are due to limitations of `scipy.sparse.csr_matrix`. These objects are not optimized to be indexed before vector-matrix or matrix-vector multiplications.