### PR TITLE
Added sublinear stepsize to FW overlap example

### DIFF
--- a/examples/frank_wolfe/plot_vertex_overlap.py
+++ b/examples/frank_wolfe/plot_vertex_overlap.py
@@ -38,7 +38,8 @@ for ax, (dataset_title, load_data) in zip(axes.ravel(), datasets):
     x0 = np.zeros(n_features)
 
     for i, (step, label, marker) in enumerate(
-        [["backtracking", "backtracking", "^"], ["DR", "DR step-size", "d"]]
+        [["backtracking", "backtracking", "^"], ["DR", "DR step-size", "d"],
+         ["sublinear", "sublinear", "s"]]
     ):
         print("Running %s variant" % label)
         st_prev = []
@@ -66,7 +67,7 @@ for ax, (dataset_title, load_data) in zip(axes.ravel(), datasets):
             x0,
             l1_ball.lmo,
             callback=trace,
-            max_iter=int(1e4),
+            max_iter=int(1e2),
             step=step,
             verbose=True,
             lipschitz=f.lipschitz,


### PR DESCRIPTION
Seems interesting that the sublinear step size never chooses the same two vertices in a row. My guess is that this is due to zigzagging behavior.

![image](https://user-images.githubusercontent.com/11814989/85133774-9cb2ce80-b23b-11ea-919c-fe1b073ff181.png)
