### PR TITLE
WIP: implementation of non-contiguous group lasso penalty GroupL1nc

### DIFF
--- a/copt/penalty.py
+++ b/copt/penalty.py
@@ -143,6 +143,97 @@ class GroupL1:
         return _prox_gl, B
 
 
+class GroupL1nc:
+    """
+    Group Lasso penalty with NON-CONTIGUOUS and NON-OVERLAPPING groups
+
+    Args:
+        alpha: float
+            Constant multiplying this loss
+
+        blocks: list of lists
+
+    """
+
+    def __init__(self, alpha, groups):
+        self.alpha = alpha
+
+        sum_groups = np.sum([len(g) for g in groups])
+        all_indices = list(groups[0])
+        for g in groups[1:]:
+            all_indices.extend(list(g))
+        n_unique = np.unique(all_indices).size
+        if sum_groups != n_unique:
+            raise ValueError('Groups must not overlap.')
+        self.groups = groups
+
+    def __call__(self, x):
+        return self.alpha * np.sum([np.linalg.norm(x[g]) for g in self.groups])
+
+    def prox(self, x, step_size):
+        out = x.copy()
+        for g in self.groups:
+            norm = np.linalg.norm(x[g])
+            if norm > self.alpha * step_size:
+                out[g] -= step_size * self.alpha * out[g] / norm
+            else:
+                out[g] = 0
+        return out
+
+    def prox_factory(self, n_features):
+        B_data = np.zeros(n_features)
+        B_indices = np.zeros(n_features, dtype=np.int32)
+        B_indptr = np.zeros(n_features + 1, dtype=np.int32)
+
+        feature_pointer = 0
+        block_pointer = 0
+        for g in self.groups:
+            for atom in g:
+                B_data[feature_pointer] = 1.
+                B_indices[feature_pointer] = atom
+                feature_pointer += 1
+            B_indptr[block_pointer + 1] = B_indptr[block_pointer] + len(g)
+            block_pointer += 1
+
+        excluded_indices = np.ones(n_features, dtype=np.int32)
+        excluded_indices[B_indices[: feature_pointer + 1]] = 0.
+        for i in np.where(excluded_indices)[0]:
+            B_data[feature_pointer] = -1.
+            B_indices[feature_pointer] = i
+            feature_pointer += 1
+
+            B_indptr[block_pointer + 1] = B_indptr[block_pointer] + 1
+            block_pointer += 1
+
+        B_indptr = B_indptr[: block_pointer + 1]
+        B = sparse.csr_matrix((B_data, B_indices, B_indptr))
+
+        alpha = self.alpha
+
+        @njit
+        def _prox_gl(x, i, indices, indptr, d, step_size):
+            for b in range(indptr[i], indptr[i + 1]):
+                h = indices[b]
+                if B_data[B_indices[B_indptr[h]]] <= 0:
+                    continue
+                ss = step_size * d[h]
+                norm = 0.0
+                for j in range(B_indptr[h], B_indptr[h + 1]):
+                    j_idx = B_indices[j]
+                    norm += x[j_idx] ** 2
+                norm = np.sqrt(norm)
+                if norm > alpha * ss:
+                    for j in range(B_indptr[h], B_indptr[h + 1]):
+                        j_idx = B_indices[j]
+                        x[j_idx] *= 1 - alpha * ss / norm
+                else:
+                    for j in range(B_indptr[h], B_indptr[h + 1]):
+                        j_idx = B_indices[j]
+                        x[j_idx] = 0.0
+
+        return _prox_gl, B
+
+
 class FusedLasso:
     """
     Fused Lasso penalty


### PR DESCRIPTION
This PR adds a new class to the copt.penalty module which defines a non-contiguous version of the existing GroupL1 penalty. The main differences between the two are:

* Parsing of the input. GroupL1nc requires just non-overlapping groups.
* Definition of `B` matrix adapted to non-contiguous setting (it's no longer block-diagonal).
* Evaluation of `_prox_gl` adapted to non-contiguous setting.
* Result of simple test adapted to new block matrix.

Minor style/PEP8 improvements have been applied to the modified files.

I've still got a couple of concerns on which I would like to have your opinion @fabianp .

* The `B` matrix in `prox_factory` that I implemented in GroupL1nc is slightly different with respect to the one of GroupL1. The difference is in how the "forgotten" features are encoded in `B`. Here's a small example. Let `n_features = 5` and `groups = [(0, 1), (3, 4)]`, then the `B` matrix for the two methods is the following:

```
b_GroupL1 = [[1.0, 1.0, 0.0, 0.0, 0.0],
                       [0.0, 0.0, -1.0, 0.0, 0.0],
                       [0.0, 0.0, 0.0, 1.0, 1.0]]

b_GroupL1nc = [[1.0, 1.0, 0.0, 0.0, 0.0],
                           [0.0, 0.0, 0.0, 1.0, 1.0],
                           [0.0, 0.0, -1.0, 0.0, 0.0]]
```
I made a few tests and it seems to me that this does not change the result, but I don't have a proof for it. What happens is that we reorder the groups by putting all the "-1" singletons after the groups. Are you aware of any reason why it shouldn't work?

* My second concern is about the group structure. Are we good with accepting only non-overlapping groups or do we want a more general code that accepts overlapping groups or even [tree structures](https://arxiv.org/abs/1009.2139)?

After solving these two points we can think of merging GroupL1 and GroupL1nc, as the latter trivially generalizes the former.