### PR TITLE
FIX dependency on sklearn package is deprecated

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     author_email="f@bianp.net",
     url="http://pypi.python.org/pypi/copt",
     packages=["copt"],
-    install_requires=["numpy", "scipy", "tqdm", "sklearn", "six"],
+    install_requires=["numpy", "scipy", "tqdm", "scikit-learn", "six"],
     classifiers=[_f for _f in CLASSIFIERS.split("\n") if _f],
     package_data={"copt": ["data/img1.csv"]},
     license="New BSD License",


### PR DESCRIPTION
The `sklearn` deps is being brown out, leading to failed install.
Moving on to use `scikit-learn` dependency.