### PR TITLE
MAINT: Use non-nested scipy.optimize namespace.

### DIFF
--- a/copt/utils.py
+++ b/copt/utils.py
@@ -28,14 +28,14 @@ except ImportError:
                 return wrapper
 
             return inner_function
-    
+
     prange = range
 
 
 def build_func_grad(jac, fun, args, eps):
     if not callable(jac):
         if bool(jac):
-            fun = optimize.optimize.MemoizeJac(fun)
+            fun = optimize.MemoizeJac(fun)
             jac = fun.derivative
         elif jac == "2-point":
             jac = None


### PR DESCRIPTION
This line results in: 

> /home/johannes.wiesner/.conda/envs/csp_wiesner_johannes/lib/python3.9/site-packages/copt/utils.py:41: DeprecationWarning:
>
> Please use MemoizeJac from the scipy.optimize namespace, the scipy.optimize.optimize namespace is deprecated.

See: https://github.com/richford/groupyr/issues/78.