### PR TITLE
FIX np.NaN is not available anymore in numpy2.0

### DIFF
--- a/copt/constraint.py
+++ b/copt/constraint.py
@@ -76,7 +76,7 @@ class L1Ball:
         if np.abs(x).sum() <= self.alpha:
             return 0
         else:
-            return np.infty
+            return np.inf
 
     def prox(self, x, step_size=None):
         """Projection onto the L-infinity ball.

--- a/copt/proximal_gradient.py
+++ b/copt/proximal_gradient.py
@@ -121,7 +121,7 @@ def minimize_proximal_gradient(
         prox = _prox
 
     success = False
-    certificate = np.NaN
+    certificate = np.nan
 
     func_and_grad = utils.build_func_grad(jac, fun, args, eps)
 

--- a/copt/splitting.py
+++ b/copt/splitting.py
@@ -288,7 +288,7 @@ def minimize_primal_dual(
         ss_ratio = tau / sigma
 
     fk, grad_fk = f_grad(x)
-    norm_incr = np.infty
+    norm_incr = np.inf
     x_next = x.copy()
 
     for it in range(max_iter):

--- a/copt/utils.py
+++ b/copt/utils.py
@@ -35,7 +35,7 @@ except ImportError:
 def build_func_grad(jac, fun, args, eps):
     if not callable(jac):
         if bool(jac):
-            fun = optimize.optimize.MemoizeJac(fun)
+            fun = optimize._optimize.MemoizeJac(fun)
             jac = fun.derivative
         elif jac == "2-point":
             jac = None


### PR DESCRIPTION
Just notived a failure with numpy 2.0.
This is a quick fix for the failure I observed.